### PR TITLE
Port from GObject to GLib

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -6,7 +6,7 @@ from gettext import gettext as _
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
-from gi.repository import GObject
+from gi.repository import GLib
 import pygame
 from sugar3.activity import activity
 from sugar3.graphics.toolbarbox import ToolbarBox

--- a/sugargame/canvas.py
+++ b/sugargame/canvas.py
@@ -1,6 +1,6 @@
 import os
 from gi.repository import Gtk
-from gi.repository import GObject
+from gi.repository import GLib
 import pygame
 import event
 
@@ -12,7 +12,7 @@ class PygameCanvas(Gtk.EventBox):
     mainwindow is the activity intself.
     """
     def __init__(self, mainwindow, pointer_hint = True):
-        GObject.GObject.__init__(self)
+        GLib.GLib.__init__(self)
 
         global CANVAS
         assert CANVAS == None, "Only one PygameCanvas can be created, ever."
@@ -37,7 +37,7 @@ class PygameCanvas(Gtk.EventBox):
         # Sugar activity is not properly created until after its constructor returns.
         # If the Pygame main loop is called from the activity constructor, the
         # constructor never returns and the activity freezes.
-        GObject.idle_add(self._run_pygame_cb, main_fn)
+        GLib.idle_add(self._run_pygame_cb, main_fn)
 
     def _run_pygame_cb(self, main_fn):
         # PygameCanvas.run_pygame can only be called once

--- a/sugargame/canvas.py
+++ b/sugargame/canvas.py
@@ -1,6 +1,7 @@
 import os
 from gi.repository import Gtk
 from gi.repository import GLib
+from gi.repository import GObject
 import pygame
 import event
 
@@ -12,7 +13,7 @@ class PygameCanvas(Gtk.EventBox):
     mainwindow is the activity intself.
     """
     def __init__(self, mainwindow, pointer_hint = True):
-        GLib.GLib.__init__(self)
+        GObject.GObject.__init__(self)
 
         global CANVAS
         assert CANVAS == None, "Only one PygameCanvas can be created, ever."

--- a/sugargame/event.py
+++ b/sugargame/event.py
@@ -1,6 +1,6 @@
 from gi.repository import Gtk
 from gi.repository import Gdk
-from gi.repository import GObject
+from gi.repository import GLib
 import pygame
 import pygame.event
 
@@ -239,9 +239,9 @@ class Translator(object):
 
     def _set_repeat(self, delay=None, interval=None):
         if delay is not None and self.__repeat[0] is None:
-            self.__tick_id = GObject.timeout_add(10, self._tick_cb)
+            self.__tick_id = GLib.timeout_add(10, self._tick_cb)
         elif delay is None and self.__repeat[0] is not None:
-            GObject.source_remove(self.__tick_id)
+            GLib.source_remove(self.__tick_id)
         self.__repeat = (delay, interval)
 
     def _get_mouse_pos(self):


### PR DESCRIPTION
### Explanation
This PR ports GObject based methods and constants references to GLib in IQ-activity.

### Reason
PyGIDeprecationWarning occurs in shell.log and activity logs when using PyGObject development releases, because of our use of GObject instead of GLib for certain methods.

### TODO
- [x] Test (Don't know how to test it, needs doc).
- [x] Verify that this [line](https://github.com/sugarlabs/iq-activity/pull/9/files#diff-0e7cb4c5bbdd52f79dd903d700945b92R15) must be changed.